### PR TITLE
fix: broken player profile icon images

### DIFF
--- a/app/equipos/[id]/page.tsx
+++ b/app/equipos/[id]/page.tsx
@@ -69,7 +69,7 @@ function PlayerCard({
       <div className="flex flex-col gap-3 px-4 py-4 flex-1">
         <div className="flex items-center gap-3">
           {stats?.profileIconId ? (
-            <Image src={`/ddragon/profileicon/${stats.profileIconId}.png`} alt="" width={40} height={40} className="rounded-lg shrink-0" />
+            <Image src={`/ddragon/profileicon/${stats.profileIconId}.png`} alt="" width={40} height={40} className="rounded-lg shrink-0" unoptimized />
           ) : (
             <div className="w-10 h-10 rounded-lg bg-white/10 shrink-0" />
           )}

--- a/components/CompareClient.tsx
+++ b/components/CompareClient.tsx
@@ -188,7 +188,7 @@ function PlayerCard({
     >
       {/* Profile icon */}
       {player.profileIconId ? (
-        <Image src={`/ddragon/profileicon/${player.profileIconId}.png`} alt="" width={36} height={36} className="rounded-lg shrink-0" />
+        <Image src={`/ddragon/profileicon/${player.profileIconId}.png`} alt="" width={36} height={36} className="rounded-lg shrink-0" unoptimized />
       ) : (
         <div className="w-9 h-9 rounded-lg bg-white/10 shrink-0" />
       )}

--- a/components/PlayerRankingTable.tsx
+++ b/components/PlayerRankingTable.tsx
@@ -147,7 +147,7 @@ export default function PlayerRankingTable({ rows }: Props) {
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2.5">
                     {r.profileIconId ? (
-                      <Image src={`/ddragon/profileicon/${r.profileIconId}.png`} alt="" width={28} height={28} className="rounded shrink-0" />
+                      <Image src={`/ddragon/profileicon/${r.profileIconId}.png`} alt="" width={28} height={28} className="rounded shrink-0" unoptimized />
                     ) : (
                       <div className="w-7 h-7 rounded bg-white/10 shrink-0" />
                     )}


### PR DESCRIPTION
## Summary
- Add `unoptimized` prop to profile icon `<Image>` components in ranking, team detail, and compare pages
- Next.js image optimization fails for local DDragon static files in standalone production builds
- Matches the pattern already used for other DDragon assets in `app/partidos/[id]/page.tsx`

## Test plan
- [ ] Player profile icons load correctly on ranking page
- [ ] Player profile icons load correctly on team detail page
- [ ] Player profile icons load correctly on compare page

🤖 Generated with [Claude Code](https://claude.com/claude-code)