### PR TITLE
fix: allow empty logo in team schema validation

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -11,7 +11,7 @@ const PlayerSchema = z.object({
 
 export const TeamSchema = z.object({
   name: z.string().min(1).max(100),
-  logo: z.string().min(1),
+  logo: z.string().default(''),
   players: z.array(PlayerSchema).default([]),
 })
 


### PR DESCRIPTION
## Summary
- `TeamSchema` required `logo` with `min(1)`, causing 422 when creating new teams with empty logo string
- Changed to `.default('')` so teams can be created without a logo

## Test plan
- [ ] Create a new team from admin panel — should succeed without 422 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)