### PR TITLE
fix: allow empty logo string in team schema validation

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -11,7 +11,7 @@ const PlayerSchema = z.object({
 
 export const TeamSchema = z.object({
   name: z.string().min(1).max(100),
-  logo: z.string().min(1),
+  logo: z.string().default(''),
   players: z.array(PlayerSchema).default([]),
 })
 


### PR DESCRIPTION
TeamSchema required logo.min(1) but new teams are created with empty string since the default logo path was removed. Changed to .default('').