### PR TITLE
feat: improve public phases view with team pools and placeholder brackets

### DIFF
--- a/app/fases/page.tsx
+++ b/app/fases/page.tsx
@@ -51,11 +51,11 @@ export default function FasesPage() {
               <SwissView phase={phase} matches={matches} teams={teams} />
             )}
             {phase.type === 'elimination' && (
-              <EliminationBracket matches={matches} teams={teams} />
+              <EliminationBracket matches={matches} teams={teams} teamCount={phase.config.bracketTeamIds?.length} />
             )}
             {phase.type === 'final-four' && (
               <>
-                <EliminationBracket matches={matches.filter(m => m.round !== 98)} teams={teams} />
+                <EliminationBracket matches={matches.filter(m => m.round !== 98)} teams={teams} teamCount={4} />
                 {matches.some(m => m.round === 98) && (
                   <div className="mt-6">
                     <p className="text-xs text-white/40 uppercase tracking-wider mb-3">3er / 4to puesto</p>

--- a/components/brackets/EliminationBracket.tsx
+++ b/components/brackets/EliminationBracket.tsx
@@ -7,6 +7,7 @@ interface Props {
   matches: Match[]
   teams: Team[]
   title?: string
+  teamCount?: number
 }
 
 const SLOT = 112    // base slot height for first round (px)
@@ -114,6 +115,21 @@ function getRoundName(ri: number, totalRounds: number) {
   return `Ronda ${ri + 1}`
 }
 
+function PlaceholderCard() {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-[#0e1117]/50">
+      <div className="flex items-center gap-2.5 px-3 h-12 border-b border-white/[0.04]">
+        <div className="w-[22px] h-[22px] rounded bg-white/5 shrink-0" />
+        <span className="text-sm text-white/15 italic">TBD</span>
+      </div>
+      <div className="flex items-center gap-2.5 px-3 h-12">
+        <div className="w-[22px] h-[22px] rounded bg-white/5 shrink-0" />
+        <span className="text-sm text-white/15 italic">TBD</span>
+      </div>
+    </div>
+  )
+}
+
 function ConnectorSVG({ numPairs, slotH }: { numPairs: number; slotH: number }) {
   const totalH = numPairs * slotH * 2
   const mx = CONN_W / 2
@@ -139,8 +155,53 @@ function ConnectorSVG({ numPairs, slotH }: { numPairs: number; slotH: number }) 
   )
 }
 
-export default function EliminationBracket({ matches, teams, title }: Props) {
+export default function EliminationBracket({ matches, teams, title, teamCount }: Props) {
   if (matches.length === 0) {
+    const numRounds = teamCount && teamCount >= 2 ? Math.log2(teamCount) : 0
+    if (numRounds >= 1) {
+      const placeholderRounds = Array.from({ length: numRounds }, (_, ri) => ({
+        ri,
+        count: teamCount! / Math.pow(2, ri + 1),
+      }))
+      return (
+        <div className="flex flex-col gap-3">
+          {title && (
+            <h3 className="text-[11px] font-bold text-white/40 uppercase tracking-widest">{title}</h3>
+          )}
+          <div className="flex overflow-x-auto pb-3">
+            {placeholderRounds.map(({ ri, count }) => {
+              const slotH = SLOT * Math.pow(2, ri)
+              const isLast = ri === placeholderRounds.length - 1
+              const vPad = (slotH - CARD_H) / 2
+              return (
+                <div key={ri} style={{ display: 'flex', alignItems: 'flex-start' }}>
+                  <div style={{ width: COL_W, flexShrink: 0 }}>
+                    <div style={{ height: HEADER_H }} className="flex items-center justify-center">
+                      <span className="text-[11px] font-bold uppercase tracking-widest text-white/20">
+                        {getRoundName(ri, numRounds)}
+                      </span>
+                    </div>
+                    {Array.from({ length: count }, (_, i) => (
+                      <div
+                        key={i}
+                        style={{ height: slotH, paddingTop: vPad, paddingBottom: vPad, paddingLeft: 6, paddingRight: 6, boxSizing: 'border-box' }}
+                      >
+                        <PlaceholderCard />
+                      </div>
+                    ))}
+                  </div>
+                  {!isLast && (
+                    <div style={{ paddingTop: HEADER_H }}>
+                      <ConnectorSVG numPairs={Math.floor(count / 2)} slotH={slotH} />
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )
+    }
     return (
       <p className="text-white/25 text-sm py-4">
         {title && <span className="text-white/40 font-medium">{title} — </span>}

--- a/components/brackets/SwissView.tsx
+++ b/components/brackets/SwissView.tsx
@@ -16,6 +16,7 @@ interface Pool {
   losses: number
   type: PoolType
   matches: Match[]
+  teamIds: string[]
 }
 
 interface RoundColumn {
@@ -96,7 +97,11 @@ function buildColumns(
     const pools: Pool[] = [...poolMap.entries()]
       .map(([key, ms]) => {
         const [w, l] = key.split('-').map(Number)
-        return { wins: w, losses: l, type: getPoolType(w, l, advW, elimL), matches: ms }
+        const poolTeamIds = teamIds.filter(id => {
+          const r = preRecords[id] ?? { wins: 0, losses: 0 }
+          return r.wins < advW && r.losses < elimL && r.wins === w && r.losses === l
+        })
+        return { wins: w, losses: l, type: getPoolType(w, l, advW, elimL), matches: ms, teamIds: poolTeamIds }
       })
       .sort((a, b) => b.wins - a.wins || a.losses - b.losses)
 
@@ -325,8 +330,21 @@ function PoolCardWithTeams({ pool, bo, confirmed, teams }: { pool: Pool; bo: num
       {/* Matches or placeholder */}
       <div className="px-2.5 pb-2.5 flex flex-col">
         {!confirmed ? (
-          <div className="py-3 text-center">
-            <span className="text-[10px] text-white/20 italic">Pendiente de confirmación</span>
+          <div className="py-2 flex flex-col gap-1.5">
+            <span className="text-[10px] text-white/20 italic text-center block mb-0.5">Pendiente de confirmación</span>
+            {pool.teamIds.map(id => {
+              const team = teams.find(t => t.id === id)
+              return (
+                <div key={id} className="flex items-center gap-1.5 px-0.5">
+                  {team?.logo ? (
+                    <Image src={team.logo} alt={team.name} width={16} height={16} className="rounded shrink-0" />
+                  ) : (
+                    <div className="w-4 h-4 rounded bg-white/5 shrink-0" />
+                  )}
+                  <span className="text-xs text-white/40 truncate">{team?.name ?? id}</span>
+                </div>
+              )
+            })}
           </div>
         ) : pool.matches.length === 0 ? (
           <div className="py-2 text-center">


### PR DESCRIPTION
## Summary

- **Swiss view**: las rondas no confirmadas ahora muestran la lista de equipos que pertenecen a cada pool W-L, calculada a partir de los records de rondas confirmadas previas. Antes solo decía "Pendiente de confirmación".
- **Elimination / Final-Four**: cuando no hay partidos generados pero la fase tiene `bracketTeamIds` configurado, se muestra un bracket vacío con slots TBD en vez de un mensaje de texto plano. Final-four siempre usa `teamCount=4`.

## Test plan

- [ ] Swiss con ronda no confirmada: cada pool muestra logo + nombre de los equipos en esa zona W-L
- [ ] Swiss con todas las rondas confirmadas: comportamiento sin cambios
- [ ] Elimination sin partidos pero con `bracketTeamIds`: muestra bracket TBD del tamaño correcto
- [ ] Elimination con partidos: comportamiento sin cambios
- [ ] Final-four sin partidos: muestra bracket de 4 equipos (2 semis + final) con TBD
- [ ] Final-four con partidos: comportamiento sin cambios
- [ ] `npm run lint` y `npm run build` sin errores ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)