### PR TITLE
fix: frontpage adjustments and TwitchEmbed live detection

### DIFF
--- a/components/TwitchEmbed.tsx
+++ b/components/TwitchEmbed.tsx
@@ -14,7 +14,9 @@ const EMBED_ID = 'twitch-embed-root'
 type AnySDK = any
 
 export default function TwitchEmbed({ channel, onLiveChange }: Props) {
-  const [isLive, setIsLive] = useState<boolean | null>(null)
+  // Default true: show embed immediately; OFFLINE event hides it if channel is not live.
+  // Twitch.Player.ONLINE only fires on transitions, not on initial load when already live.
+  const [isLive, setIsLive] = useState(true)
   const onLiveChangeRef = useRef(onLiveChange)
   useEffect(() => { onLiveChangeRef.current = onLiveChange }, [onLiveChange])
 


### PR DESCRIPTION
## Summary

- **Frontpage redesign**: extracted `LiveSection` component, simplified `app/page.tsx`
- **TwitchEmbed**: fix live detection — default `isLive` to `true` so embed shows immediately on load; OFFLINE event hides it if channel is not live (Twitch.Player.ONLINE only fires on transitions, not initial load)
- **Ranking**: show all players, replace dev-facing error messages with user-friendly text
- **DDragon profile icons**: add proxy route `GET /api/ddragon/profileicon/[id]`
- **Admin**: minor UI tweaks in fases and partidos pages

## Test plan

- [ ] Verify Twitch embed is visible immediately when channel is live on page load
- [ ] Verify embed is hidden when channel is offline
- [ ] Verify ranking shows all players with friendly error messages
- [ ] Verify DDragon profile icons load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)