### PR TITLE
fix: Twitch embed visible on load and profile icons on-demand download

### DIFF
--- a/app/api/ddragon/profileicon/[id]/route.ts
+++ b/app/api/ddragon/profileicon/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { PROFILE_ICONS_DIR } from '@/lib/env'
+import { ensureProfileIcon } from '@/lib/ddragon'
 import { readFile } from 'fs/promises'
 import path from 'path'
 
@@ -12,6 +13,8 @@ export async function GET(
   if (!/^\d+$/.test(id)) {
     return NextResponse.json({ error: 'ID no válido' }, { status: 400 })
   }
+
+  await ensureProfileIcon(parseInt(id, 10))
 
   const filePath = path.join(PROFILE_ICONS_DIR, `${id}.png`)
 

--- a/components/LiveSection.tsx
+++ b/components/LiveSection.tsx
@@ -8,7 +8,8 @@ interface Props {
 }
 
 export default function LiveSection({ channel }: Props) {
-  const [isLive, setIsLive] = useState<boolean | null>(null)
+  // Default true: show embed immediately; TwitchEmbed fires OFFLINE if not live.
+  const [isLive, setIsLive] = useState<boolean | null>(true)
 
   return (
     <>


### PR DESCRIPTION
## Summary

- **Twitch embed**: `LiveSection` arrancaba con `isLive=null` (falsy) → la sección se renderizaba como `h-0 overflow-hidden`, ocultando el embed desde el inicio. Ahora arranca en `true`; el evento `OFFLINE` del SDK lo oculta si el canal no está en directo.
- **Iconos de perfil**: la ruta `/api/ddragon/profileicon/[id]` solo leía del disco y devolvía 404 si el archivo no existía. Ahora llama a `ensureProfileIcon()` antes de leer, descargando el icono de DDragon on-demand si no está cacheado localmente.

## Test plan

- [ ] Verificar que el embed de Twitch es visible al cargar la home (con `TWITCH_CHANNEL` configurado)
- [ ] Verificar que los iconos de perfil de los jugadores cargan correctamente en `/ranking`
- [ ] Verificar que iconos nuevos se descargan automáticamente sin reiniciar el servidor

🤖 Generated with [Claude Code](https://claude.com/claude-code)