### PR TITLE
fix(ranking): normalize summonerName to fix duplicate players

### DIFF
--- a/app/api/riot/refresh-stats/route.ts
+++ b/app/api/riot/refresh-stats/route.ts
@@ -169,14 +169,15 @@ async function runRefresh(teamIds?: string[]) {
     }))
 
     // Deduplicar rows (un jugador en varios equipos puede aparecer varias veces)
+    const normalizeName = (name: string) => name.trim().replace(/\s*#\s*/g, '#').toLowerCase()
     const dedupedMap = new Map<string, PlayerRow>()
-    for (const r of rows) dedupedMap.set(r.summonerName.toLowerCase(), r)
+    for (const r of rows) dedupedMap.set(normalizeName(r.summonerName), r)
     const uniqueRows = Array.from(dedupedMap.values())
 
     // Merge parcial: mantener jugadores no refrescados del cache anterior
-    const refreshedNames = new Set(uniqueRows.map(r => r.summonerName.toLowerCase()))
+    const refreshedNames = new Set(uniqueRows.map(r => normalizeName(r.summonerName)))
     const kept = previousCache.players.filter(
-      p => !refreshedNames.has(p.summonerName.toLowerCase())
+      p => !refreshedNames.has(normalizeName(p.summonerName))
     )
     savePlayerStatsCache({ lastUpdated: new Date().toISOString(), players: [...kept, ...uniqueRows] })
 

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -17,10 +17,13 @@ export default function RankingPage() {
   const teams = getTeams()
   const teamLookup = new Map(teams.map(t => [t.id, { logo: t.logo, name: t.name }]))
 
+  // Normaliza el nombre para deduplicar: trim + eliminar espacios alrededor del '#'
+  const normalizeName = (name: string) => name.trim().replace(/\s*#\s*/g, '#').toLowerCase()
+
   // Jugadores en cache deduplicados (la BD puede contener entradas duplicadas)
   const seenInCache = new Map<string, PlayerRow>()
   for (const r of cache.players) {
-    const key = r.summonerName.toLowerCase()
+    const key = normalizeName(r.summonerName)
     if (!seenInCache.has(key)) seenInCache.set(key, r)
   }
   const cachedNames = new Set(seenInCache.keys())
@@ -33,7 +36,7 @@ export default function RankingPage() {
   // Jugadores en el roster que aún no tienen datos en cache
   const pendingRows: PlayerRow[] = teams.flatMap(team =>
     (team.players ?? [])
-      .filter(p => !cachedNames.has(p.summonerName.toLowerCase()))
+      .filter(p => !cachedNames.has(normalizeName(p.summonerName)))
       .map(p => ({
         summonerName: p.summonerName,
         puuid: '',


### PR DESCRIPTION
## Summary
- Adds `normalizeName()` helper that trims whitespace and collapses spaces around `#` before comparing summonerNames
- Fixes case where `"Shablo #EUW"` (space before `#`) and `"Shablo#EUW"` were treated as different players, causing the same player to appear twice in the ranking
- Applied in both `app/ranking/page.tsx` (dedup at render time) and `app/api/riot/refresh-stats/route.ts` (dedup at cache write time)

## Test plan
- [ ] Verify Report JGL players no longer appear duplicated in the ranking
- [ ] Verify other teams are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)